### PR TITLE
Make credentials print statement a warning.

### DIFF
--- a/statsbombpy/api_client.py
+++ b/statsbombpy/api_client.py
@@ -4,6 +4,7 @@ import requests as req
 from requests_cache import install_cache
 
 import statsbombpy.entities as ents
+import warnings
 from statsbombpy.config import CACHED_CALLS_SECS, HOSTNAME, VERSIONS
 
 install_cache(mkdtemp(), backend="sqlite", expire_after=CACHED_CALLS_SECS)
@@ -11,7 +12,7 @@ install_cache(mkdtemp(), backend="sqlite", expire_after=CACHED_CALLS_SECS)
 
 def has_auth(creds):
     if creds.get("user") in [None, ""] or creds.get("passwd") in [None, ""]:
-        print("credentials were not supplied. open data access only")
+        warnings.warn("credentials were not supplied. open data access only")
         return False
     return True
 


### PR DESCRIPTION
The "credentials were not supplied. open data access only" statement in the has_auth function used to be a print statement, which got very annoying to work with for users without credentials. Having it be a warning statement makes it easier for users to surpress these repeated statements, eg. with warnings.filterwarnings("ignore").